### PR TITLE
Default expiration

### DIFF
--- a/api/manage.py
+++ b/api/manage.py
@@ -15,7 +15,7 @@ class LinkJob(BaseModel):
     """Link model."""
     code: str
     url: str
-    expiration: str = Field("", description="Expiration date and time in YYYY-MM-DD format.")
+    expiration: str = Field("3000-01-01", description="Expiration date and time in YYYY-MM-DD format.")
     password: str = Field("", description="Password for management.")
 
     @validator("expiration")

--- a/shortlinks/__init__.py
+++ b/shortlinks/__init__.py
@@ -18,7 +18,7 @@ def find_shortlink(code: str) -> str:
     return ""
 
 
-def create_shortlink(url: str, code: str, expiration: datetime = None) -> bool:
+def create_shortlink(url: str, code: str, expiration: datetime = datetime(3000, 1, 1)) -> bool:
     """Create a shortlink. Returns False if the chosen code exists."""
     if find_shortlink(code):  # if a non-expired shortlink already exists
         return False


### PR DESCRIPTION
All shortlink documents in the database will now have an `expiration` field. The default expiration is `3000-01-01` or Jan 1 of the year 3,000. This way standardized expiration checks can happen on all documents.