### PR TITLE
Use new IP location provider

### DIFF
--- a/keys/models.py
+++ b/keys/models.py
@@ -17,7 +17,7 @@ class MongoDBModel(BaseModel):
     connect_str: str
 
 
-class ipstackModel(BaseModel):
+class APILayerModel(BaseModel):
     """ipstack API credentials."""
     api_key: str
 
@@ -26,4 +26,4 @@ class Keys(BaseModel):
     """Overall keys."""
     General: GeneralModel
     MongoDB: MongoDBModel
-    ipstack: ipstackModel
+    APILayer: APILayerModel

--- a/shortlinks/tracking/__init__.py
+++ b/shortlinks/tracking/__init__.py
@@ -8,11 +8,22 @@ from shortlinks.database import SHORTLINKS
 
 
 def ip_to_city(ip: str) -> str:
-    """Get city from IP address. If city is not found, return the IP address."""
-    url = f"http://api.ipstack.com/{ip}?access_key={KEYS.ipstack.api_key}"
-    res = requests.get(url)
-    res.raise_for_status()
-    return res.json()["city"] or ip
+    """
+    Get city and region, formatted, from IP address. Ex City, Region.
+    If city is not found, return the IP address.
+    """
+    try:
+        res = requests.get(
+            f"https://api.apilayer.com/ip_to_location/{ip}",
+            headers={
+                "apikey": KEYS.APILayer.api_key
+            }
+        )
+        res_json = res.json()
+        city, region = res_json["city"], res_json["region_name"]
+        return f"{city}, {region}"
+    except (KeyError, requests.exceptions.RequestException):
+        return ip
 
 
 def track_click(ip: str, code: str) -> None:


### PR DESCRIPTION
Fixes #6.

Use APILayer's ip_to_location API instead. And, instead of just getting the city, get the city _and_ region, which for American cities means city and state.