### PR TITLE
Upgrade to Pydantic v2

### DIFF
--- a/api/manage.py
+++ b/api/manage.py
@@ -1,6 +1,6 @@
 """CRUD operations for the links."""
 from fastapi import APIRouter
-from pydantic import BaseModel, Field, validator
+from pydantic import field_validator, BaseModel, Field
 
 from datetime import datetime
 
@@ -19,7 +19,7 @@ class LinkJob(BaseModel):
     expiration: str = Field("3000-01-01", description="Expiration date and time in YYYY-MM-DD format.")
     password: str = Field("", description="Password for management.")
 
-    @validator("expiration")
+    @field_validator("expiration")
     def expiration_datetime(cls, v):
         """Validate expiration."""
         if v:
@@ -70,7 +70,7 @@ class ExpirationChangeJob(BaseModel):
     new_expiration: str = Field("3000-01-01", description="Expiration date and time in YYYY-MM-DD format.")
     password: str = Field("", description="Password for management.")
 
-    @validator("new_expiration")
+    @field_validator("new_expiration")
     def expiration_datetime(cls, v):
         """Validate expiration."""
         if v:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.101.1
+pydantic==2.2.1
 pymongo==4.4.1
 pyyaml==6.0.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.100.0
+fastapi==0.101.1
 pymongo==4.4.1
 pyyaml==6.0.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyyaml==6.0.1
 
 # Server
 gunicorn==21.2.0
-uvicorn==0.23.1
+uvicorn==0.23.2
 
 # Tracking
 requests==2.31.0


### PR DESCRIPTION
Entirely in the API. No Pydantic is used in the actual `shortlinks` package.

Also upgrade some API packages, ex. FastAPI to 100+ for Pydantic v2 support, and just gunicorn and uvicorn to their latest versions.